### PR TITLE
Add new TopicController registration method

### DIFF
--- a/src/LeanCode.LeanPipe/SubscriptionHandler.cs
+++ b/src/LeanCode.LeanPipe/SubscriptionHandler.cs
@@ -24,12 +24,12 @@ public class KeyedSubscriptionHandler<TTopic> : ISubscriptionHandler<TTopic>
     public async Task OnSubscribedAsync(TTopic topic, LeanPipeSubscriber pipe)
     {
         var context = new LeanPipeContext(
-            pipe.Context.GetHttpContext() ?? throw new InvalidOperationException("Connection is not associated with an HTTP request.")
+            pipe.Context.GetHttpContext()
+                ?? throw new InvalidOperationException(
+                    "Connection is not associated with an HTTP request."
+                )
         );
-        var keys = await topicController.ToKeysAsync(
-            topic,
-            context
-        );
+        var keys = await topicController.ToKeysAsync(topic, context);
         foreach (var key in keys)
         {
             await pipe.Groups.AddToGroupAsync(
@@ -46,7 +46,10 @@ public class KeyedSubscriptionHandler<TTopic> : ISubscriptionHandler<TTopic>
         // if we subscribe to topic.something and topic.something.specific,
         // then we do not know when to unsubscribe from topic.something
         var context = new LeanPipeContext(
-            pipe.Context.GetHttpContext() ?? throw new InvalidOperationException("Connection is not associated with an HTTP request.")
+            pipe.Context.GetHttpContext()
+                ?? throw new InvalidOperationException(
+                    "Connection is not associated with an HTTP request."
+                )
         );
         var keys = await topicController.ToKeysAsync(topic, context);
         foreach (var key in keys)


### PR DESCRIPTION
I also wonder if `PublishAsync` method which uses `ITopicController<TTopic, TNotification>` should fallback to `ITopicController<TTopic>` if `ITopicController<TTopic, TNotification>` has not been registered. What do you think?