### PR TITLE
Fix ITopicKeys API

### DIFF
--- a/publisher/src/LeanPipe/ITopicKeys.cs
+++ b/publisher/src/LeanPipe/ITopicKeys.cs
@@ -5,17 +5,21 @@ namespace LeanPipe;
 public interface ITopicKeys<in TTopic>
     where TTopic : ITopic
 {
-    ValueTask<IEnumerable<string>> GetAsync(TTopic topic, LeanPipeContext context);
+    ValueTask<IEnumerable<string>> GetForSubscribingAsync(TTopic topic, LeanPipeContext context);
+    ValueTask<IEnumerable<string>> GetForPublishingAsync(
+        TTopic topic,
+        CancellationToken ct = default
+    );
 }
 
 public interface INotificationKeys<in TTopic, TNotification> : ITopicKeys<TTopic>
     where TTopic : ITopic, IProduceNotification<TNotification>
     where TNotification : notnull
 {
-    ValueTask<IEnumerable<string>> GetAsync(
+    ValueTask<IEnumerable<string>> GetForPublishingAsync(
         TTopic topic,
         TNotification notification,
-        LeanPipeContext context
+        CancellationToken ct = default
     );
 }
 
@@ -24,6 +28,13 @@ public abstract class BasicTopicKeys<TTopic> : ITopicKeys<TTopic>
 {
     public abstract IEnumerable<string> Get(TTopic topic);
 
-    public ValueTask<IEnumerable<string>> GetAsync(TTopic topic, LeanPipeContext context) =>
-        ValueTask.FromResult(Get(topic));
+    public ValueTask<IEnumerable<string>> GetForSubscribingAsync(
+        TTopic topic,
+        LeanPipeContext context
+    ) => ValueTask.FromResult(Get(topic));
+
+    public ValueTask<IEnumerable<string>> GetForPublishingAsync(
+        TTopic topic,
+        CancellationToken ct = default
+    ) => ValueTask.FromResult(Get(topic));
 }

--- a/publisher/src/LeanPipe/LeanPipePublisher.cs
+++ b/publisher/src/LeanPipe/LeanPipePublisher.cs
@@ -33,9 +33,24 @@ public static class LeanPipePublisherExtensions
 {
     public static async Task PublishAsync<TTopic, TNotification>(
         this LeanPipePublisher<TTopic> publisher,
+        IEnumerable<string> keys,
         TTopic topic,
         TNotification notification,
-        LeanPipeContext context
+        CancellationToken ct = default
+    )
+        where TTopic : ITopic, IProduceNotification<TNotification>
+        where TNotification : notnull
+    {
+        var payload = NotificationEnvelope.Create(topic, notification);
+
+        await publisher.PublishAsync(keys, payload, ct);
+    }
+
+    public static async Task PublishAsync<TTopic, TNotification>(
+        this LeanPipePublisher<TTopic> publisher,
+        TTopic topic,
+        TNotification notification,
+        CancellationToken ct = default
     )
         where TTopic : ITopic, IProduceNotification<TNotification>
         where TNotification : notnull
@@ -43,40 +58,26 @@ public static class LeanPipePublisherExtensions
         var notificationKeys = publisher.ServiceProvider.GetRequiredService<
             INotificationKeys<TTopic, TNotification>
         >();
-        var keys = await notificationKeys.GetAsync(topic, notification, context);
+
+        var keys = await notificationKeys.GetForPublishingAsync(topic, notification, ct);
         var payload = NotificationEnvelope.Create(topic, notification);
 
-        await publisher.PublishAsync(keys, payload, context.HttpContext.RequestAborted);
-    }
-
-    public static async Task PublishAsync<TTopic, TNotification>(
-        this LeanPipePublisher<TTopic> publisher,
-        string[] keys,
-        TTopic topic,
-        TNotification notification,
-        LeanPipeContext context
-    )
-        where TTopic : ITopic, IProduceNotification<TNotification>
-        where TNotification : notnull
-    {
-        var payload = NotificationEnvelope.Create(topic, notification);
-
-        await publisher.PublishAsync(keys, payload, context.HttpContext.RequestAborted);
+        await publisher.PublishAsync(keys, payload, ct);
     }
 
     public static async Task PublishToTopicAsync<TTopic, TNotification>(
         this LeanPipePublisher<TTopic> publisher,
         TTopic topic,
         TNotification notification,
-        LeanPipeContext context
+        CancellationToken ct = default
     )
         where TTopic : ITopic, IProduceNotification<TNotification>
         where TNotification : notnull
     {
         var topicKeys = publisher.ServiceProvider.GetRequiredService<ITopicKeys<TTopic>>();
-        var keys = await topicKeys.GetAsync(topic, context);
+        var keys = await topicKeys.GetForPublishingAsync(topic, ct);
         var payload = NotificationEnvelope.Create(topic, notification);
 
-        await publisher.PublishAsync(keys, payload, context.HttpContext.RequestAborted);
+        await publisher.PublishAsync(keys, payload, ct);
     }
 }

--- a/publisher/src/LeanPipe/SubscriptionHandler.cs
+++ b/publisher/src/LeanPipe/SubscriptionHandler.cs
@@ -25,7 +25,7 @@ public class KeyedSubscriptionHandler<TTopic> : ISubscriptionHandler<TTopic>
         LeanPipeContext context
     )
     {
-        var keys = await topicKeys.GetAsync(topic, context);
+        var keys = await topicKeys.GetForSubscribingAsync(topic, context);
         foreach (var key in keys)
         {
             await pipe.Groups.AddToGroupAsync(
@@ -45,7 +45,7 @@ public class KeyedSubscriptionHandler<TTopic> : ISubscriptionHandler<TTopic>
         // with this implementation there is a problem of "higher level" groups:
         // if we subscribe to topic.something and topic.something.specific,
         // then we do not know when to unsubscribe from topic.something
-        var keys = await topicKeys.GetAsync(topic, context);
+        var keys = await topicKeys.GetForSubscribingAsync(topic, context);
         foreach (var key in keys)
         {
             await pipe.Groups.RemoveFromGroupAsync(

--- a/publisher/test/LeanPipe.Tests.Additional/TopicWithoutAllKeys.cs
+++ b/publisher/test/LeanPipe.Tests.Additional/TopicWithoutAllKeys.cs
@@ -15,7 +15,7 @@ public class TopicWithoutAllKeysKeys
     : ITopicKeys<TopicWithoutAllKeys>,
         INotificationKeys<TopicWithoutAllKeys, Notification1>
 {
-    public ValueTask<IEnumerable<string>> GetAsync(
+    public ValueTask<IEnumerable<string>> GetForSubscribingAsync(
         TopicWithoutAllKeys topic,
         LeanPipeContext context
     )
@@ -23,10 +23,18 @@ public class TopicWithoutAllKeysKeys
         return new(Array.Empty<string>());
     }
 
-    public ValueTask<IEnumerable<string>> GetAsync(
+    public ValueTask<IEnumerable<string>> GetForPublishingAsync(
+        TopicWithoutAllKeys topic,
+        CancellationToken ct = default
+    )
+    {
+        return new(Array.Empty<string>());
+    }
+
+    public ValueTask<IEnumerable<string>> GetForPublishingAsync(
         TopicWithoutAllKeys topic,
         Notification1 notification,
-        LeanPipeContext context
+        CancellationToken ct = default
     )
     {
         return new(Array.Empty<string>());

--- a/publisher/test/LeanPipe.Tests/StubHandler.cs
+++ b/publisher/test/LeanPipe.Tests/StubHandler.cs
@@ -26,7 +26,15 @@ public class StubHandler : StubHandler<Topic1> { }
 public class DummyKeys<T> : ITopicKeys<T>
     where T : ITopic
 {
-    public ValueTask<IEnumerable<string>> GetAsync(T topic, LeanPipeContext context)
+    public ValueTask<IEnumerable<string>> GetForSubscribingAsync(T topic, LeanPipeContext context)
+    {
+        return new(Enumerable.Empty<string>());
+    }
+
+    public ValueTask<IEnumerable<string>> GetForPublishingAsync(
+        T topic,
+        CancellationToken ct = default
+    )
     {
         return new(Enumerable.Empty<string>());
     }
@@ -37,19 +45,19 @@ public class TopicWithAllKeysKeys
         INotificationKeys<TopicWithAllKeys, Notification1>,
         INotificationKeys<TopicWithAllKeys, Notification2>
 {
-    public ValueTask<IEnumerable<string>> GetAsync(
+    public ValueTask<IEnumerable<string>> GetForPublishingAsync(
         TopicWithAllKeys topic,
         Notification1 notification,
-        LeanPipeContext context
+        CancellationToken ct = default
     )
     {
         return new(Array.Empty<string>());
     }
 
-    public ValueTask<IEnumerable<string>> GetAsync(
+    public ValueTask<IEnumerable<string>> GetForPublishingAsync(
         TopicWithAllKeys topic,
         Notification2 notification,
-        LeanPipeContext context
+        CancellationToken ct = default
     )
     {
         return new(Array.Empty<string>());


### PR DESCRIPTION
Somewhere in redesigning topic keys with @jakubfijalkowski we missed the fact that there is no `LeanPipeContext` (which could be actually called LeanPipeSubscriptionContext) when you're publishing a notification - you're just a handler that wants to publish something. This actually makes current version of LeanPipe unusable 🙈 which I've found out veeery quickly trying to include some example in our example app.

The split of having different methods for 2 purposes of getting keys fixes it (but API could still be better probably 🤔 - we'll try to improve things when we have the examples), while being in line with our vision of TopicKeys, however some other problems are highlighted: 

- a lack of some sort of integration tests that would fully ensure our supported cases work and a situation like this never happens - I'll try to bring them in somehow.
- `LeanPipeContext` could've have a better name like my proposed `LeanPipeSubscriptionContext`, but that seems long 😕 