### PR TITLE
Fix Hub constructor visibility

### DIFF
--- a/publisher/src/LeanPipe/LeanPipeSubscriber.cs
+++ b/publisher/src/LeanPipe/LeanPipeSubscriber.cs
@@ -9,7 +9,7 @@ public class LeanPipeSubscriber : Hub
     private readonly SubscriptionHandlerResolver resolver;
     private readonly IEnvelopeDeserializer deserializer;
 
-    internal LeanPipeSubscriber(
+    public LeanPipeSubscriber(
         SubscriptionHandlerResolver resolver,
         IEnvelopeDeserializer deserializer
     )


### PR DESCRIPTION
It can't be fetched from DI with `internal` ctor. Also one more argument to have broader LeanPipe tests.