### PR TITLE
Fix topic deserialization exception

### DIFF
--- a/publisher/src/LeanPipe/LeanPipeSubscriber.cs
+++ b/publisher/src/LeanPipe/LeanPipeSubscriber.cs
@@ -80,7 +80,7 @@ public class LeanPipeSubscriber : Hub
         {
             await NotifyResultAsync(envelope.Id, SubscriptionStatus.Malformed, type);
             throw new InvalidOperationException(
-                $"Cannot deserialize topic {envelope.Topic} of type {envelope.TopicType}.",
+                $"Cannot deserialize topic {envelope.Topic.RootElement.GetRawText()} of type {envelope.TopicType}.",
                 e
             );
         }


### PR DESCRIPTION
Before it was always the default `ToString()` of `JsonDocument` which had the default `object.ToString()` implementation.