### PR TITLE
Fix subscribing and publishing logs

### DIFF
--- a/publisher/src/LeanCode.Pipe/LeanPipePublisher.cs
+++ b/publisher/src/LeanCode.Pipe/LeanPipePublisher.cs
@@ -58,8 +58,8 @@ internal class LeanPipePublisher<TTopic> : ILeanPipePublisher<TTopic>
         logger.Information(
             "Published notification {NotificationType} to {GroupCount} groups of topic {TopicType}",
             payload.NotificationType,
-            payload.TopicType,
-            keys.Count()
+            keys.Count(),
+            payload.TopicType
         );
     }
 }

--- a/publisher/src/LeanCode.Pipe/SubscriptionExecutor.cs
+++ b/publisher/src/LeanCode.Pipe/SubscriptionExecutor.cs
@@ -139,7 +139,7 @@ public class SubscriptionExecutor : ISubscriptionExecutor
 
         if (result)
         {
-            logger.Debug(
+            logger.Information(
                 "Subscription operation {SubscriptionOperation} on topic {TopicType} completed successfully",
                 type,
                 envelope.TopicType


### PR DESCRIPTION
After all I think subscribing and unsubscribing deserves an information level log.