### PR TITLE
Fix NuGet config for CPM

### DIFF
--- a/publisher/NuGet.config
+++ b/publisher/NuGet.config
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear/>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="LeanCode Nightly Feed" value="https://f.feedz.io/leancode/public/nuget/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="LeanCode Nightly Feed">
+      <package pattern="*"/>
+    </packageSource>
+  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
Previously generating packages generated many CPM warnings and I've missed that.