### PR TITLE
Switch to .NET 8.0 and bump packages

### DIFF
--- a/.github/workflows/dart_integration_tests.yml
+++ b/.github/workflows/dart_integration_tests.yml
@@ -18,7 +18,7 @@ jobs:
     name: Test Dart client compliance with Publisher
     runs-on: ubuntu-latest
     env:
-      DOTNET_VERSION: 8.0.100-rc.1.23463.5
+      DOTNET_VERSION: 8.0.100
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
     timeout-minutes: 20

--- a/.github/workflows/funnel_msvc_tests.yml
+++ b/.github/workflows/funnel_msvc_tests.yml
@@ -19,7 +19,7 @@ jobs:
       run:
         working-directory: ./publisher
     env:
-      DOTNET_VERSION: 8.0.100-rc.1.23463.5
+      DOTNET_VERSION: 8.0.100
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
     timeout-minutes: 20

--- a/.github/workflows/publisher_ci.yml
+++ b/.github/workflows/publisher_ci.yml
@@ -19,7 +19,7 @@ jobs:
       run:
         working-directory: ./publisher
     env:
-      DOTNET_VERSION: 8.0.100-rc.1.23463.5
+      DOTNET_VERSION: 8.0.100
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
     steps:

--- a/.github/workflows/publisher_release.yml
+++ b/.github/workflows/publisher_release.yml
@@ -12,7 +12,7 @@ jobs:
       run:
         working-directory: ./publisher
     env:
-      DOTNET_VERSION: 8.0.100-rc.1.23463.5
+      DOTNET_VERSION: 8.0.100
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
     steps:

--- a/publisher/Directory.Packages.props
+++ b/publisher/Directory.Packages.props
@@ -2,7 +2,8 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 
-    <CoreLibVersion>8.0.2183-preview</CoreLibVersion>
+    <CoreLibVersion>8.0.2301-preview</CoreLibVersion>
+    <MassTransitVersion>8.1.2</MassTransitVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,19 +14,19 @@
     <PackageVersion Include="LeanCode.IntegrationTestHelpers" Version="$(CoreLibVersion)" />
     <PackageVersion Include="LeanCode.Logging" Version="$(CoreLibVersion)" />
 
-    <PackageVersion Include="MassTransit.RabbitMQ" Version="8.1.1" />
-    <PackageVersion Include="MassTransit.SignalR" Version="8.1.1" />
+    <PackageVersion Include="MassTransit.RabbitMQ" Version="$(MassTransitVersion)" />
+    <PackageVersion Include="MassTransit.SignalR" Version="$(MassTransitVersion)" />
 
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0-rc.1.23421.29" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />
 
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageVersion Include="xunit.analyzers" Version="1.3.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.1" />
-    <PackageVersion Include="xunit" Version="2.5.1" />
+    <PackageVersion Include="xunit.analyzers" Version="1.5.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageVersion Include="xunit" Version="2.6.1" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
 
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />

--- a/publisher/global.json
+++ b/publisher/global.json
@@ -1,7 +1,7 @@
 {
     "sdk": {
-        "allowPrerelease": true,
-        "rollForward": "major",
-        "version": "8.0.100-rc.1.23463.5"
+        "allowPrerelease": false,
+        "rollForward": "latestMinor",
+        "version": "8.0.100"
     }
 }


### PR DESCRIPTION
The new warnings are kinda much, so I'll tackle that in another PR.