### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/publisher_ci.yml
+++ b/.github/workflows/publisher_ci.yml
@@ -39,15 +39,17 @@ jobs:
         run: dotnet build --no-restore
       - name: Test Publisher
         run: >
-          dotnet test ./test/LeanCode.Pipe.Tests/LeanCode.Pipe.Tests.csproj
+          dotnet test
+          ./test/LeanCode.Pipe.Tests/LeanCode.Pipe.Tests.csproj
           --no-build
           --collect "XPlat Code Coverage"
           --settings test/coverlet.runsettings
           --logger trx
           --results-directory TestResults
-      - name: Test test client
+      - name: Test Test Client
         run: >
-          dotnet test ./test/LeanCode.Pipe.TestClient.Tests/LeanCode.Pipe.TestClient.Tests.csproj
+          dotnet test
+          ./test/LeanCode.Pipe.TestClient.Tests/LeanCode.Pipe.TestClient.Tests.csproj
           --no-build
           --collect "XPlat Code Coverage"
           --settings test/coverlet.runsettings
@@ -55,7 +57,8 @@ jobs:
           --results-directory TestResults
       - name: Integration test
         run: >
-          dotnet test ./test/LeanCode.Pipe.IntegrationTests/LeanCode.Pipe.IntegrationTests.csproj
+          dotnet test
+          ./test/LeanCode.Pipe.IntegrationTests/LeanCode.Pipe.IntegrationTests.csproj
           --no-build
           --collect "XPlat Code Coverage"
           --settings test/coverlet.runsettings
@@ -64,7 +67,8 @@ jobs:
           -e EnableFunnel=false
       - name: Integration test with Funnel
         run: >
-          dotnet test ./test/LeanCode.Pipe.IntegrationTests/LeanCode.Pipe.IntegrationTests.csproj
+          dotnet test
+          ./test/LeanCode.Pipe.IntegrationTests/LeanCode.Pipe.IntegrationTests.csproj
           --no-build
           --collect "XPlat Code Coverage"
           --settings test/coverlet.runsettings

--- a/.github/workflows/publisher_release.yml
+++ b/.github/workflows/publisher_release.yml
@@ -39,10 +39,32 @@ jobs:
         env:
           BUILD_VERSION: ${{ steps.version.outputs.version }}
         run: dotnet build --no-restore -c Release
-      - name: Test
-        env:
-          BUILD_VERSION: ${{ steps.version.outputs.version }}
-        run: dotnet test --no-build -c Release
+      - name: Test Publisher
+        run: >
+          dotnet test
+          ./test/LeanCode.Pipe.Tests/LeanCode.Pipe.Tests.csproj
+          --no-build
+          -c Release
+      - name: Test Test Client
+        run: >
+          dotnet test
+          ./test/LeanCode.Pipe.TestClient.Tests/LeanCode.Pipe.TestClient.Tests.csproj
+          --no-build
+          -c Release
+      - name: Integration test
+        run: >
+          dotnet test
+          ./test/LeanCode.Pipe.IntegrationTests/LeanCode.Pipe.IntegrationTests.csproj
+          --no-build
+          -c Release
+          -e EnableFunnel=false
+      - name: Integration test with Funnel
+        run: >
+          dotnet test
+          ./test/LeanCode.Pipe.IntegrationTests/LeanCode.Pipe.IntegrationTests.csproj
+          --no-build
+          -c Release
+          -e EnableFunnel=true
       - name: Pack Publisher
         env:
           BUILD_VERSION: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
We cannot simply `dotnet test` as there are now µsvc tests here as well. I don't have any better idea than specifying all test projects, but it's not too bad.