### PR TITLE
use signalr_core from pub, bump uuid to ^4.5.1

### DIFF
--- a/dart/CHANGELOG.md
+++ b/dart/CHANGELOG.md
@@ -4,6 +4,8 @@
 - **Breaking:** Bump minimum Dart vesion to 3.5.0
 - Bump `custom_lint` dependency to `^0.7.0`
 - Bump `test` dependency to `1.25.14`
+- Bump `uuid` dependency to `^4.5.1`
+- Bump `signalr_core` dependency to `^1.1.2`
 
 ## 0.1.0
 

--- a/dart/pubspec.lock
+++ b/dart/pubspec.lock
@@ -481,12 +481,11 @@ packages:
   signalr_core:
     dependency: "direct main"
     description:
-      path: "."
-      ref: "feature/bump-dart-and-package-versions"
-      resolved-ref: d32848eaa8c0d0073c49cefa39feb20181fd44ad
-      url: "https://github.com/RCSandberg/signalr_core.git"
-    source: git
-    version: "1.1.1"
+      name: signalr_core
+      sha256: "27c4ce798c8fedc2f7e3e4668c2b1dbcf6ee2a93f40ad24284b5f5bbed84529d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
   source_gen:
     dependency: transitive
     description:
@@ -527,6 +526,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.1"
+  sprintf:
+    dependency: transitive
+    description:
+      name: sprintf
+      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   sse:
     dependency: transitive
     description:
@@ -538,12 +545,11 @@ packages:
   sse_channel:
     dependency: transitive
     description:
-      path: "."
-      ref: "feature/bump-dart-and-package-versions"
-      resolved-ref: "50c4b76f2f37ee3d0dad6b7f46678482fdcc546c"
-      url: "https://github.com/RCSandberg/sse_channel.git"
-    source: git
-    version: "0.0.3"
+      name: sse_channel
+      sha256: "9aad5d4eef63faf6ecdefb636c0f857bd6f74146d2196087dcf4b17ab5b49b1b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
   stack_trace:
     dependency: transitive
     description:
@@ -636,10 +642,10 @@ packages:
     dependency: "direct main"
     description:
       name: uuid
-      sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
+      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.7"
+    version: "4.5.1"
   vm_service:
     dependency: transitive
     description:

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -16,12 +16,8 @@ dependencies:
   logging: ^1.2.0
   meta: ^1.9.1
   rxdart: ^0.28.0
-  # TODO: bring back pub version once merged and published
-  signalr_core:
-    git:
-      url: https://github.com/RCSandberg/signalr_core.git
-      ref: feature/bump-dart-and-package-versions
-  uuid: ^3.0.7
+  signalr_core: ^1.1.2
+  uuid: ^4.5.1
 
 dev_dependencies:
   build_runner: 2.4.11


### PR DESCRIPTION
Replace signalr_core dependency from github with the one from pub. -> required bump of the uuid
todo: update changlelog